### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"repository": {
 		"type": "git",
-		"url": "git+ssh://git@github.com/mehm8128/rehype-toc.git"
+		"url": "git+https://github.com/mehm8128/rehype-toc.git"
 	},
 	"homepage": "https://github.com/mehm8128/rehype-toc",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

This updates the package metadata repository URL from the SSH form to the public HTTPS form.

The current npm metadata points to `git+ssh://git@github.com/mehm8128/rehype-toc.git`, which requires SSH/GitHub key setup for consumers following the package repository link. The HTTPS URL points to the same public repository and works without SSH credentials.

## Validation

- `node -e 'const p=require("./package.json"); if (p.repository.url !== "git+https://github.com/mehm8128/rehype-toc.git") throw new Error(p.repository.url)'`
- `git diff --check`
- `git ls-remote https://github.com/mehm8128/rehype-toc.git HEAD`
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec biome check package.json`
- `pnpm pack --dry-run`
